### PR TITLE
Remove `markdownify` from `render-image.html` caption

### DIFF
--- a/layouts/_default/_markup/render-image.html
+++ b/layouts/_default/_markup/render-image.html
@@ -37,8 +37,8 @@
       {{- end }}
     {{- end }}
     <a href="{{ $image }}" target="calligraphy-image">
-      <img loading="lazy" src="{{ $thumbnail }}" alt="{{ .Text | default "A Decorative Image" | markdownify }}">
+      <img loading="lazy" src="{{ $thumbnail }}" alt="{{ .Text | default "A Decorative Image" }}">
     </a>
   {{- end }}
-  {{ with .Text }}<figcaption class="text-small">{{ . | markdownify  }}</figcaption>{{ end }}
+  {{ with .Text }}<figcaption class="text-small">{{ . | safeHTML }}</figcaption>{{ end }}
 </figure>


### PR DESCRIPTION
<!--
  ## READ BEFORE OPENING PULL REQUESTS
  - Thank you for contributing to Calligraphy!
  - Please fill the template below so we can better process the request.
-->
## Description

As part of [Hugo v0.94.0](https://github.com/gohugoio/hugo/releases/tag/v0.94.0):

> We now fail with error when double-rendering text in markdownify/RenderString

## Motivation and Context

Closes #1 

## Screenshots

<!--
  If applicable, add screenshots to help showcase any visual changes.

  You can use `Windows+Shift+S` or `Control+Command+Shift+5` to add a screenshot to your clipboard and then paste it here.
-->

## Checklist:

- [X] I have enabled [maintainer edits for this pull request](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [X] I have verified that the code works as described/as intended.
- [X] I have **not** included any CDN resources/links, or I have used `hugo mod vendor`.
- [X] I have updated the `README.md`, as applicable.
- [X] I have updated the `theme.toml`, as applicable.
