### PR TITLE
Add a partial for authors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+public
+resources

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -1,5 +1,6 @@
 baseURL = "https://hugo-calligraphy.netlify.app/"
 title = "Calligraphy"
+theme = "calligraphy"
 copyright = "Copyright © 2021"
 paginate = 6
 languageCode = "en"

--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -1,0 +1,2 @@
+[and]
+other = "and"

--- a/i18n/fr.toml
+++ b/i18n/fr.toml
@@ -1,0 +1,2 @@
+[and]
+other = "et"

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -16,23 +16,8 @@
                     {{ with .Params.series }}<a href="/series/{{ . | urlize }}" class="card__series" data-taxonomy="{{ print "series-" . | urlize }}">{{ . }}</a>{{ end }}
                     <h2 class="card__title"><a href="{{ .RelPermalink }}">{{ .Title }}</a></h2>
                     {{ with .Params.subtitle }} <span class="card__subtitle">{{ . }}</span>{{ end }}
-                    {{ with .Params.authors }}
                     <div class="card__meta">
-                        <span class="card__authors">
-                            {{ $authors := . }}
-                            {{ $count := len $authors }}
-                            {{ if eq $count 1 }}
-                                {{ index $authors 0 }}
-                            {{ else if eq $count 2 }}
-                                {{ index $authors 0 }} and {{ index $authors 1 }}
-                            {{ else }}
-                                {{ range $index, $author := $authors }}
-                                    {{ if gt $index 0 }}, {{ end }}{{ $author }}
-                                    {{ if eq $index (sub $count 1) }} and {{ end }}
-                                {{ end }}
-                            {{ end }}
-                        </span>
-                        {{ end }}
+                        {{ partial "authors-list.html" .Params.authors }}
                         {{ with .PublishDate }}<time datetime="{{ . }}" class="card__date">{{ cond (eq (.Format "2006") (now.Format "2006")) (.Format "Jan 2") (.Format "2 Jan 2006") }}</time>{{ end }}
                     </div>
                 </div>

--- a/layouts/_default/term.html
+++ b/layouts/_default/term.html
@@ -21,23 +21,8 @@
             {{ with .Params.series }}<a href="/series/{{ . | urlize }}" class="card__series" data-taxonomy="{{ print "series-" . | urlize }}">{{ . }}</a>{{ end }}
             <h2 class="card__title"><a href="{{ .RelPermalink }}">{{ .Title }}</a></h2>
             {{ with .Params.subtitle }} <span class="card__subtitle">{{ . }}</span>{{ end }}
-            {{ with .Params.authors }}
             <div class="card__meta">
-                <span class="card__authors">
-                    {{ $authors := . }}
-                    {{ $count := len $authors }}
-                    {{ if eq $count 1 }}
-                        {{ index $authors 0 }}
-                    {{ else if eq $count 2 }}
-                        {{ index $authors 0 }} and {{ index $authors 1 }}
-                    {{ else }}
-                        {{ range $index, $author := $authors }}
-                            {{ if gt $index 0 }}, {{ end }}{{ $author }}
-                            {{ if eq $index (sub $count 1) }} and {{ end }}
-                        {{ end }}
-                    {{ end }}
-                </span>
-                {{ end }}
+                {{ partial "authors-list.html" .Params.authors }}
                 {{ with .PublishDate }}<time datetime="{{ . }}" class="card__date">{{ cond (eq (.Format "2006") (now.Format "2006")) (.Format "Jan 2") (.Format "2 Jan 2006") }}</time>{{ end }}
             </div>
         </div>

--- a/layouts/blog/single.html
+++ b/layouts/blog/single.html
@@ -14,22 +14,7 @@
         <h1 class="card__title"><a href="{{ .RelPermalink }}">{{ .Title }}</a></h1>
         {{ with .Params.subtitle }}<span class="card__subtitle">{{ . }}</span>{{ end }}
         <div class="card__meta">
-            {{ with .Params.authors }}
-            <span class="card__authors">
-                {{ $authors := . }}
-                {{ $count := len $authors }}
-                {{ if eq $count 1 }}
-                    {{ index $authors 0 }}
-                {{ else if eq $count 2 }}
-                    {{ index $authors 0 }} and {{ index $authors 1 }}
-                {{ else }}
-                    {{ range $index, $author := $authors }}
-                        {{ if gt $index 0 }}, {{ end }}{{ $author }}
-                        {{ if eq $index (sub $count 1) }} and {{ end }}
-                    {{ end }}
-                {{ end }}
-            </span>
-            {{ end }}
+            {{ partial "authors-list.html" .Params.authors }}
             {{ with .PublishDate }}<time datetime="{{ . }}" class="card__date">{{ cond (eq (.Format "2006") (now.Format "2006")) (.Format "Jan 2") (.Format "2 Jan 2006") }}</time>{{ end }}
         </div>
     </div>

--- a/layouts/partials/authors-list.html
+++ b/layouts/partials/authors-list.html
@@ -1,0 +1,11 @@
+{{ $authors := . }}
+{{ $count := len $authors }}
+
+<span class="card__authors">
+  {{ range $index, $author := $authors }}
+    {{ $authorPage := site.GetPage "taxonomyTerm" (printf "authors/%s" $author | urlize) }}
+    <a href="{{ $authorPage.RelPermalink }}">{{ $authorPage.Title }}</a>
+    {{- if lt $index (sub $count 2) }}, {{ end -}}
+    {{ if eq $index (sub $count 2) }} {{ T "and" }} {{ end }}
+  {{ end }}
+</span>


### PR DESCRIPTION
## Description

remove little bug when follow https://hugo-calligraphy.netlify.app/blog/theme-installation/
add a partial for authors which is more concise, display title if available and link to author page

## Motivation and Context

Better integration

## Screenshots
![image](https://github.com/user-attachments/assets/65aa9311-0f2b-4dd2-af25-dd2c7ec8cf52)


## Checklist:

- [x] I have enabled [maintainer edits for this pull request](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have verified that the code works as described/as intended.
- [x] I have **not** included any CDN resources/links, or I have used `hugo mod vendor`.
- [X] I have updated the `README.md`, as applicable.
- [X] I have updated the `theme.toml`, as applicable.
